### PR TITLE
updated node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "autoprefixer": "^6.4.1",
     "minireset.css": "0.0.2",
-    "node-sass": "^3.9.3",
+    "node-sass": "^4.7.2",
     "postcss-cli": "^2.6.0"
   },
   "files": [


### PR DESCRIPTION
Installation of the library was failing in nodeJS 8 (and above presumably) due to an incompatible version of node-sass. I updated that to be the latest and now it seems to install into projects correctly.

I ran a build (`npm run build`) and got no errors, so I assume all is good. :)

Thank you for this great library and I hope you find some time to update the version and publish it to npm. 

/Paul