### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/jgthms/wysiwyg.css/issues"
   },
   "homepage": "https://github.com/jgthms/wysiwyg.css#readme",
-  "dependencies": {
+  "devDependencies": {
     "autoprefixer": "^6.4.1",
     "minireset.css": "0.0.2",
     "node-sass": "^4.7.2",


### PR DESCRIPTION
It will allow to not install build dependencies when installing `wysiwyg`

For now I have a problem, that `npm install wysiwyg.css` leads to install of outdated version of `browserslist` (which is part of autoprefixer)
And this outdated `browserslist` somehow interfere with my actual version of `browserslist` and causes my `postcss` to work not properly

So this PR:
- fix outdated `browserslist` interference
- speed up `npm install` by not installing not needed packages